### PR TITLE
PST-393: Upload and Download methods return Result[]

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php">
+<phpunit
+        colors="true"
+        bootstrap="tests/bootstrap.php"
+>
     <testsuites>
         <testsuite name="Unit tests">
             <directory>tests</directory>

--- a/src/Artifacts.php
+++ b/src/Artifacts.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\Artifacts;
 
-use JetBrains\PhpStorm\Pure;
 use Keboola\StorageApi\Client as StorageClient;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\FileUploadOptions;

--- a/src/Artifacts.php
+++ b/src/Artifacts.php
@@ -136,7 +136,7 @@ class Artifacts
         return $result;
     }
 
-    #[Pure] private function resolveDownloadPath(string $jobId, string $type): string
+    private function resolveDownloadPath(string $jobId, string $type): string
     {
         if ($type === self::DOWNLOAD_TYPE_CUSTOM) {
             return $this->filesystem->getDownloadCustomJobsDir($jobId);
@@ -207,7 +207,7 @@ class Artifacts
                     $tags->getJobId(),
                     $fileId
                 ));
-                $results[] = new Result($file['id']);
+                $results[] = new Result($fileId, $tags->getIsShared());
             }
             return $results;
         } catch (ProcessFailedException | ClientException $e) {

--- a/src/Artifacts.php
+++ b/src/Artifacts.php
@@ -75,14 +75,26 @@ class Artifacts
         }
 
         $isArchive = $configuration['artifacts']['options']['zip'] ?? self::ZIP_DEFAULT;
+
         if (!empty($configuration['artifacts']['runs']['enabled'])) {
-            $artifactsRunsConfiguration = $configuration['artifacts']['runs'];
+            $filter = $configuration['artifacts']['runs']['filter'];
             return $this->downloadRuns(
-                Tags::mergeWithConfiguration($tags, $configuration),
-                $artifactsRunsConfiguration['filter']['limit'] ?? null,
-                $artifactsRunsConfiguration['filter']['date_since'] ?? null,
+                Tags::mergeWithConfiguration($tags, $filter),
+                $filter['limit'] ?? null,
+                $filter['date_since'] ?? null,
                 self::DOWNLOAD_TYPE_RUNS,
                 $isArchive,
+            );
+        }
+
+        if (!empty($configuration['artifacts']['custom']['enabled'])) {
+            $filter = $configuration['artifacts']['custom']['filter'];
+            return $this->downloadRuns(
+                Tags::mergeWithConfiguration($tags, $filter),
+                $filter['limit'] ?? null,
+                $filter['date_since'] ?? null,
+                self::DOWNLOAD_TYPE_CUSTOM,
+                $isArchive
             );
         }
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,12 +7,18 @@ namespace Keboola\Artifacts;
 class Result
 {
     public function __construct(
-        private readonly int $storageFileId
+        private readonly int $storageFileId,
+        private readonly bool $isShared = false
     ) {
     }
 
     public function getStorageFileId(): int
     {
         return $this->storageFileId;
+    }
+
+    public function isShared(): bool
+    {
+        return $this->isShared;
     }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Artifacts;
+
+class Result
+{
+    public function __construct(
+        private readonly int $storageFileId
+    ) {
+    }
+
+    public function getStorageFileId(): int
+    {
+        return $this->storageFileId;
+    }
+}

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -66,12 +66,12 @@ class Tags
         return $this->isShared;
     }
 
-    public static function fromConfiguration(array $configuration = []): self
+    public static function mergeWithConfiguration(Tags $tags, array $configuration = []): self
     {
-        $artifactsCustomConfiguration = $configuration['artifacts']['custom'];
-        $componentId = $artifactsCustomConfiguration['filter']['component_id'];
-        $configId = $artifactsCustomConfiguration['filter']['config_id'];
-        $branchId = $artifactsCustomConfiguration['filter']['branch_id'] ?? ClientWrapper::BRANCH_DEFAULT;
+        $tagsFromConfiguration = $configuration['artifacts']['runs']['filter'];
+        $componentId = $tagsFromConfiguration['component_id'] ?? $tags->getComponentId();
+        $configId = $tagsFromConfiguration['config_id'] ?? $tags->getConfigId();
+        $branchId = $tagsFromConfiguration['branch_id'] ?? $tags->getBranchId();
 
         return new self(
             $branchId,

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -68,9 +68,9 @@ class Tags
     public static function mergeWithConfiguration(Tags $tags, array $filter): self
     {
         return new self(
+            $filter['branch_id'] ?? $tags->getBranchId(),
             $filter['component_id'] ?? $tags->getComponentId(),
             $filter['config_id'] ?? $tags->getConfigId(),
-            $filter['branch_id'] ?? $tags->getBranchId(),
         );
     }
 

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -67,15 +67,10 @@ class Tags
 
     public static function mergeWithConfiguration(Tags $tags, array $filter): self
     {
-        $tagsFromConfiguration = $filter;
-        $componentId = $tagsFromConfiguration['component_id'] ?? $tags->getComponentId();
-        $configId = $tagsFromConfiguration['config_id'] ?? $tags->getConfigId();
-        $branchId = $tagsFromConfiguration['branch_id'] ?? $tags->getBranchId();
-
         return new self(
-            $branchId,
-            $componentId,
-            $configId
+            $filter['component_id'] ?? $tags->getComponentId(),
+            $filter['config_id'] ?? $tags->getConfigId(),
+            $filter['branch_id'] ?? $tags->getBranchId(),
         );
     }
 

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Keboola\Artifacts;
 
 use DateTime;
-use Keboola\StorageApiBranch\ClientWrapper;
 
 class Tags
 {
@@ -66,9 +65,9 @@ class Tags
         return $this->isShared;
     }
 
-    public static function mergeWithConfiguration(Tags $tags, array $configuration = []): self
+    public static function mergeWithConfiguration(Tags $tags, array $filter): self
     {
-        $tagsFromConfiguration = $configuration['artifacts']['runs']['filter'];
+        $tagsFromConfiguration = $filter;
         $componentId = $tagsFromConfiguration['component_id'] ?? $tags->getComponentId();
         $configId = $tagsFromConfiguration['config_id'] ?? $tags->getConfigId();
         $branchId = $tagsFromConfiguration['branch_id'] ?? $tags->getBranchId();

--- a/tests/ArtifactsTest.php
+++ b/tests/ArtifactsTest.php
@@ -9,6 +9,7 @@ use Generator;
 use Keboola\Artifacts\Artifacts;
 use Keboola\Artifacts\ArtifactsException;
 use Keboola\Artifacts\Filesystem;
+use Keboola\Artifacts\Result;
 use Keboola\Artifacts\Tags;
 use Keboola\StorageApi\Client as StorageClient;
 use Keboola\StorageApi\ClientException;
@@ -79,8 +80,10 @@ class ArtifactsTest extends TestCase
             $configuration
         );
 
-        self::assertCount($expectedCurrentCount, $uploadedFiles['current']);
-        self::assertCount($expectedSharedCount, $uploadedFiles['shared']);
+        $current = array_filter($uploadedFiles, fn ($item) => !$item->isShared());
+        $shared = array_filter($uploadedFiles, fn ($item) => $item->isShared());
+        self::assertCount($expectedCurrentCount, $current);
+        self::assertCount($expectedSharedCount, $shared);
 
         // wait for file to be available in Storage
         sleep(1);
@@ -93,7 +96,8 @@ class ArtifactsTest extends TestCase
         self::assertCount($expectedCurrentCount, $storageFiles);
 
         $storageFile = current($storageFiles);
-        $uploadedFileCurrent = array_pop($uploadedFiles['current']);
+        $uploadedFileCurrent = array_pop($current);
+        self::assertNotNull($uploadedFileCurrent);
         $this->downloadAndAssertStorageFile($filesystem, $storageFile, $uploadedFileCurrent, [
             'artifact',
             'branchId-branch-123',
@@ -110,7 +114,8 @@ class ArtifactsTest extends TestCase
 
         if (!empty($storageFiles)) {
             $storageFile = current($storageFiles);
-            $uploadedFileShared = array_shift($uploadedFiles['shared']);
+            $uploadedFileShared = array_shift($shared);
+            self::assertNotNull($uploadedFileShared);
             $this->downloadAndAssertStorageFile($filesystem, $storageFile, $uploadedFileShared, [
                 'artifact',
                 'branchId-branch-123',
@@ -299,15 +304,14 @@ class ArtifactsTest extends TestCase
             $temp
         );
 
-        $result = $artifacts->download(new Tags(
+        $results = $artifacts->download(new Tags(
             $branchId,
             $componentId,
             $configId,
             (string) rand(0, 999999)
         ), $configuration);
 
-        self::assertCount($expectedCount, $result);
-        self::assertArrayHasKey('storageFileId', $result[0]);
+        self::assertCount($expectedCount, $results);
 
         $downloadDir = empty($configuration['artifacts']['custom']['enabled'])
             ? $artifacts->getFilesystem()->getDownloadRunsDir()
@@ -446,7 +450,6 @@ class ArtifactsTest extends TestCase
         ), $configuration);
 
         self::assertCount(count($expectedFiles), $result);
-        self::assertArrayHasKey('storageFileId', $result[0]);
 
         $downloadDir = empty($configuration['artifacts']['custom']['enabled'])
             ? $artifacts->getFilesystem()->getDownloadRunsDir()
@@ -823,7 +826,7 @@ class ArtifactsTest extends TestCase
             $logger,
             $temp
         );
-        $result = $artifacts->download(
+        $results = $artifacts->download(
             new Tags(
                 $branchId,
                 'keboola.some-component',
@@ -840,8 +843,7 @@ class ArtifactsTest extends TestCase
             ]
         );
 
-        self::assertCount($count, $result);
-        self::assertArrayHasKey('storageFileId', $result[0]);
+        self::assertCount($count, $results);
 
         $this->assertFilesAndContent($artifacts->getFilesystem()->getDownloadSharedDir());
     }
@@ -849,20 +851,19 @@ class ArtifactsTest extends TestCase
     private function downloadAndAssertStorageFile(
         Filesystem $filesystem,
         array $storageFile,
-        array $uploadedStorageFile,
+        Result $uploadedResult,
         array $tags,
         bool $unzip = true
     ): void {
         $storageClient = $this->getStorageClient();
 
-        self::assertSame(['storageFileId' => $storageFile['id']], $uploadedStorageFile);
-        self::assertSame($uploadedStorageFile['storageFileId'], $storageFile['id']);
+        self::assertSame($storageFile['id'], $uploadedResult->getStorageFileId());
         foreach ($tags as $tag) {
             self::assertContains($tag, $storageFile['tags']);
         }
 
         $downloadedArtifactPath = $unzip ? '/tmp/downloaded.tar.gz' : '/tmp/' . $storageFile['name'];
-        $storageClient->downloadFile($uploadedStorageFile['storageFileId'], $downloadedArtifactPath);
+        $storageClient->downloadFile($uploadedResult->getStorageFileId(), $downloadedArtifactPath);
 
         if ($unzip) {
             $filesystem->extractArchive($downloadedArtifactPath, '/tmp');

--- a/tests/ArtifactsTest.php
+++ b/tests/ArtifactsTest.php
@@ -267,7 +267,7 @@ class ArtifactsTest extends TestCase
     }
 
     /** @dataProvider downloadRunsProvider */
-    public function testDownloadRuns(
+    public function testDownloadRunsSimple(
         string $branchId,
         string $componentId,
         string $configId,
@@ -295,6 +295,8 @@ class ArtifactsTest extends TestCase
             self::TYPE_CURRENT,
             $configuration
         );
+
+        sleep(1);
 
         $logger = new TestLogger();
         $temp = new Temp();
@@ -417,7 +419,7 @@ class ArtifactsTest extends TestCase
             'keboola.component',
             '123',
             null,
-            5,
+            1,
             self::TYPE_CURRENT,
             $configuration
         );
@@ -428,7 +430,7 @@ class ArtifactsTest extends TestCase
             'keboola.component-2',
             '456',
             null,
-            5,
+            1,
             self::TYPE_CURRENT,
             $configuration
         );

--- a/tests/ArtifactsTest.php
+++ b/tests/ArtifactsTest.php
@@ -227,15 +227,14 @@ class ArtifactsTest extends TestCase
             $temp
         );
 
-        $result = $artifacts->upload(new Tags(
+        $results = $artifacts->upload(new Tags(
             'main-branch',
             'keboola.orchestrator',
             '123456',
             '123456789'
         ));
 
-        self::assertEmpty($result['current']);
-        self::assertEmpty($result['shared']);
+        self::assertEmpty($results);
     }
 
     public function testUploadConfigIdNull(): void


### PR DESCRIPTION
This PR actually solves too things:

1. `Artifacts::upload` and `Artifacts::download` methods now returns a list of Result objects. This will simplify and clarify working with artifacts results further in DockerBundle/JobRunner.
2. Same configuration now works for `runs` and `custom` artifacts type -> we will deprecate the `custom` type and merge those two together. For now it's backward compatible. As you can see, the tests didn't change in this regard.

I've also sped up the tests by removing unnecessary uploads of files in "NoZip" tests 5x -> 2x.