### PR TITLE
chore: Allow keboola/storage-api-client:^16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Run tests'
-        run: 'docker-compose run --rm tests composer ci'
+        run: 'docker compose run --rm tests composer ci'

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "scripts": {
         "tests": "phpunit",
         "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices",
-        "phpstan": "phpstan analyse --no-progress -c phpstan.neon",
+        "phpstan": "phpstan analyse --no-progress -c phpstan.neon --memory-limit=-1",
         "phpcs": "phpcs -n --ignore=vendor --extensions=php .",
         "phpcbf": "phpcbf -n --ignore=vendor --extensions=php .",
         "ci": [

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "ext-json": "*",
         "keboola/php-temp": ">=1.0",
-        "keboola/storage-api-client": "^15.1",
+        "keboola/storage-api-client": "^15.1|^16.0",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "symfony/filesystem": "^6.2",
         "symfony/finder": "^6.2"


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-883
Stejny pripad jako na wrapperu https://github.com/keboola/storage-api-php-client-branch-wrapper/pull/29

Potrebuju updatnout service-container na keboola/storage-api-client:^16 (https://github.com/keboola/job-queue/pull/510) a k tomu potrebuju, aby i artifacts to dovoloval.

Z changelogu (https://github.com/keboola/storage-api-php-client/releases/tag/v16.0.0) BC pro verzi 16 bylo odstraneni stare shareBucket metody, nahrazeni za shareOrganizationBucket, ktera se tu nijak primo nevyuziva, takze by to IMHO melo byt safe.