### PR TITLE
chore: Allow keboola/storage-api-client:^17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "ext-json": "*",
         "keboola/php-temp": ">=1.0",
-        "keboola/storage-api-client": "^15.1|^16.0",
+        "keboola/storage-api-client": "^15.1|^16.0|^17.0",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "symfony/filesystem": "^6.2",
         "symfony/finder": "^6.2"


### PR DESCRIPTION
V duchu https://github.com/keboola/artifacts/pull/20 povoleni Storage API klienta ve verzi 17.

BC tam byl dropnuti `createTableWithConfiguration`, co se tu stejne nepouziva.